### PR TITLE
Fix API indexing and latest note retrieval

### DIFF
--- a/simplemcp/src/server/notes_server.py
+++ b/simplemcp/src/server/notes_server.py
@@ -54,7 +54,7 @@ def get_latest_note() -> str:
     """
     ensure_file()
     with open(NOTES_FILE, "r") as f:
-        lines = f.readline()
+        lines = f.readlines()
     return lines[-1].strip() if lines else "No notes yet!"
 
 

--- a/study_buddy/interfaces/api/routes.py
+++ b/study_buddy/interfaces/api/routes.py
@@ -1,7 +1,9 @@
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 from app.ingestion.pdf_reader import extract_text_from_pdf
-from app.embedding.indexer import index_text
+from app.ingestion.chunker import chunk_text
+from app.embedding.embedder import embed_text
+from app.embedding.indexer import index_text_chunks
 from app.embedding.retriever import retrieve_relevant_chunks
 from app.agents.study_agent import answer_with_context
 
@@ -10,7 +12,9 @@ async def upload_pdf(request: Request):
     file = form["file"]
     contents = await file.read()
     text = extract_text_from_pdf(contents)
-    index_text(text)
+    chunks = chunk_text(text)
+    embeddings = embed_text(chunks)
+    index_text_chunks(chunks, embeddings)
     return JSONResponse({"message": "File indexed successfully"})
 
 async def ask_question(request: Request):


### PR DESCRIPTION
## Summary
- fix `get_latest_note` to read all notes correctly
- index uploaded PDFs in API route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843e83af3ec8327b6d3b5a6658f9d94