### PR TITLE
Update study agent integration

### DIFF
--- a/study_buddy/app/agents/study_agent.py
+++ b/study_buddy/app/agents/study_agent.py
@@ -71,6 +71,17 @@ async def run_team_agent(
         return "Error: failed to generate team response."
 
 
+async def answer_with_pdfs(
+    question: str,
+    pdf_paths: Optional[List[str]] = None,
+    url_pdfs: Optional[List[str]] = None,
+) -> str:
+    """Convenience wrapper to query PDFs using the team agent."""
+    if not pdf_paths and not url_pdfs:
+        return "No PDF sources provided."
+    return await run_team_agent(question, local_pdfs=pdf_paths, url_pdfs=url_pdfs)
+
+
 import asyncio
 from app.agents.pdf_agent import PdfAgent
 from app.agents.url_agent import URLAgent


### PR DESCRIPTION
## Summary
- expose an `answer_with_pdfs` helper in `study_agent`
- allow the web interface to upload PDFs for use with `study_agent`
- make `web_main` use `answer_with_pdfs` when answering questions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6850177357748327a308da3f3f0d0b07